### PR TITLE
Updated scripts to accurately reflect stencil update

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
 		"dist/"
 	],
 	"scripts": {
-		"build": "stencil build",
-		"start": "stencil build --dev --watch --serve",
-		"test": "jest",
-		"test.watch": "jest --watch"
-	},
+  "test": "stencil test --spec",
+  "test.watch": "stencil test --spec --watch",
+  "test.e2e": "stencil test --e2e"
+},
 	"author": "Domantas Mauruča <domantas.mauruca@gmail.com>",
 	"license": "MIT",
 	"bugs": {


### PR DESCRIPTION
jest references were removed and replaced with the updated conventions.

I wasn't sure if you needed the import { Config } updated as well. I left it off for now.