### PR TITLE
Update stencil to latest build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
 		"dist/"
 	],
 	"scripts": {
-  "test": "stencil test --spec",
-  "test.watch": "stencil test --spec --watch",
-  "test.e2e": "stencil test --e2e"
-},
+		"build": "stencil build",
+		"start": "stencil build --dev --watch --serve",
+		"test": "jest",
+		"test.watch": "jest --watch"
+	},
 	"author": "Domantas Mauruča <domantas.mauruca@gmail.com>",
 	"license": "MIT",
 	"bugs": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
 	"scripts": {
 		"build": "stencil build",
 		"start": "stencil build --dev --watch --serve",
-		"test": "jest",
-		"test.watch": "jest --watch"
+		"test": "stencil test --spec",
+    "test.watch": "stencil test --spec --watch",
+    "test.e2e": "stencil test --e2e"
 	},
 	"author": "Domantas Mauruča <domantas.mauruca@gmail.com>",
 	"license": "MIT",
@@ -40,7 +41,6 @@
 		"url": "git+https://github.com/Dohxis/air-datepicker.git"
 	},
 	"homepage": "https://github.com/Dohxis/air-datepicker",
-	"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
 		"moduleFileExtensions": [
 			"ts",
 			"tsx",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
 		"dist/"
 	],
 	"scripts": {
-		"build": "stencil build",
-		"start": "stencil build --dev --watch --serve",
-		"test": "jest",
-		"test.watch": "jest --watch"
-	},
+  "test": "stencil test --spec",
+  "test.watch": "stencil test --spec --watch",
+  "test.e2e": "stencil test --e2e"
+},
 	"author": "Domantas Mauruča <domantas.mauruca@gmail.com>",
 	"license": "MIT",
 	"bugs": {

--- a/package.json
+++ b/package.json
@@ -32,20 +32,14 @@
 	],
 	"dependencies": {},
 	"devDependencies": {
-		"@stencil/core": "^0.11.2",
-		"@types/jest": "^23.3.1",
-		"jest": "^23.4.2"
+		"@stencil/core": "^0.13.2"
 	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Dohxis/air-datepicker.git"
 	},
 	"homepage": "https://github.com/Dohxis/air-datepicker",
-	"jest": {
-		"transform": {
-			"^.+\\.(ts|tsx)$": "<rootDir>/node_modules/@stencil/core/testing/jest.preprocessor.js"
-		},
-		"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+	"testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
 		"moduleFileExtensions": [
 			"ts",
 			"tsx",


### PR DESCRIPTION
Manually updated Stencil to 0.13.2 and removed Jest and @type/jest dependencies. Also removed configuration for Jest.